### PR TITLE
remove reference to issue 18238 - no longer relevant

### DIFF
--- a/portability.rst
+++ b/portability.rst
@@ -84,9 +84,6 @@ Threads and signals
     doesn't work before the creation of the first thread on
     FreeBSD 6"
 
-* "Issue #18238: sigwaitinfo() can be interrupted on Linux (raises
-  InterruptedError), but not on AIX"
-
 * Signal orders
 * HP-UX11
 * depending on the OS, a signal sent to the pid is received by the mainthread


### PR DESCRIPTION
Issue 18238 is no longer relevant. Remove reference.

Do not know when it was resolved (or the skip was even removed).

For Documentation - test extract -

> 
> root@x066:[/data/prj/python/python3-3.7.4]./python -m test -v test_signal | grep wait
> test_sigtimedwait (test.test_signal.PendingSignalsTests) ... ok
> test_sigtimedwait_negative_timeout (test.test_signal.PendingSignalsTests) ... ok
> test_sigtimedwait_poll (test.test_signal.PendingSignalsTests) ... ok
> test_sigtimedwait_timeout (test.test_signal.PendingSignalsTests) ... ok
> test_sigwait (test.test_signal.PendingSignalsTests) ... ok
> test_sigwait_thread (test.test_signal.PendingSignalsTests) ... ok
> test_sigwaitinfo (test.test_signal.PendingSignalsTests) ... ok
> 