### PR TITLE
Update count of new core devs

### DIFF
--- a/core_devs.rst
+++ b/core_devs.rst
@@ -47,6 +47,20 @@ Statistics
 Statistics on *new* CPython core developer per year using `devguide
 <https://devguide.python.org/developers/>`_ as data:
 
+* 1989: 1
+* 1992: 2
+* 1994: 1
+* 1996: 2
+* 1997: 1
+* 1998: 3
+* 1999: 2
+* 2000: 17
+* 2001: 10
+* 2002: 8
+* 2003: 7
+* 2004: 7
+* 2005: 4
+* 2006: 7
 * 2007: 10
 * 2008: 13
 * 2009: 7
@@ -61,6 +75,8 @@ Statistics on *new* CPython core developer per year using `devguide
 * 2018: 6
 * 2019: 7
 * 2020: 5
+* 2021: 3
+* 2022: 8
 
 Links:
 

--- a/core_devs.rst
+++ b/core_devs.rst
@@ -47,16 +47,16 @@ Statistics
 Statistics on *new* CPython core developer per year using `devguide
 <https://devguide.python.org/developers/>`_ as data:
 
-* 2007: 15
-* 2008: 19
-* 2009: 11
-* 2010: 20
-* 2011: 12
-* 2012: 9
-* 2013: 4
-* 2014: 10
+* 2007: 10
+* 2008: 13
+* 2009: 7
+* 2010: 16
+* 2011: 11
+* 2012: 7
+* 2013: 3
+* 2014: 6
 * 2015: 2
-* 2016: 5
+* 2016: 4
 * 2017: 4
 * 2018: 6
 * 2019: 7


### PR DESCRIPTION
Generated from running this script in the root of https://github.com/python/devguide to process the numbers from https://devguide.python.org/core-developers/developer-log/

```python
import csv
from collections import Counter

with open("core-developers/developers.csv") as f:
    reader = csv.DictReader(
        f, fieldnames=["name", "username", "joined", "left", "notes"]
    )
    counter = Counter(row["joined"][:4] for row in reader)

# print(counter.most_common())
# print(sorted(counter.items()))

for year in sorted(counter):
    print(f"* {year}: {counter[year]}")
```

I didn't dig into why some of the existing numbers for 2007-2014 and 2016 are now lower (added in own commit for a clearer diff: https://github.com/vstinner/pythondev/commit/b8e1763c96bcab062f5a44f8ecc63109b139b521)

